### PR TITLE
remove duplicate fields and not required configuration

### DIFF
--- a/production-secure-deploy/confluent-platform-production.yaml
+++ b/production-secure-deploy/confluent-platform-production.yaml
@@ -38,7 +38,6 @@ spec:
           secretRef: credential
       tls:
         enabled: true
-        secretRef: tls-group1
     external:
       authentication:
         type: plain
@@ -52,20 +51,12 @@ spec:
           bootstrapPrefix: rb
       tls:
         enabled: true
-        secretRef: tls-group1
   authorization:
     type: rbac
     superUsers:
     - User:kafka
     - User:ANONYMOUS
   services:
-    restProxy:
-      enabled: true
-      mds:
-        authentication:
-          type: bearer
-          bearer:
-            secretRef: mds-client
     mds:
       tls:
         enabled: true

--- a/production-secure-deploy/confluent-platform-production.yaml
+++ b/production-secure-deploy/confluent-platform-production.yaml
@@ -86,17 +86,12 @@ spec:
   dependencies:
     zookeeper:
       endpoint: zookeeper.confluent.svc.cluster.local:2182
+      authentication:
+        type: digest
+        jaasConfig:
+          secretRef: credential
       tls:
         enabled: true
-  metricReporter:
-    enabled: true
-    bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
-    authentication:
-      type: plain
-      jaasConfig:
-        secretRef: credential
-    tls:
-      enabled: true
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Connect

--- a/production-secure-deploy/confluent-platform-production.yaml
+++ b/production-secure-deploy/confluent-platform-production.yaml
@@ -57,6 +57,13 @@ spec:
     - User:kafka
     - User:ANONYMOUS
   services:
+    restProxy:
+      enabled: true
+      mds:
+        authentication:
+          type: bearer
+          bearer:
+            secretRef: mds-client
     mds:
       tls:
         enabled: true


### PR DESCRIPTION
- Kafka CR can reference global TLS (.spec.tls.) if all the features share the same certificate. 
- Configure Kafka to talk to ZK with digest authentication.