### PR TITLE
Use Helm to Install Ingress Controller

### DIFF
--- a/external-access-static-host-based/README.rst
+++ b/external-access-static-host-based/README.rst
@@ -162,18 +162,18 @@ SSL passthrough is the action of passing data through a load balancer to a serve
 In many load balancer use cases, the decryption or SSL termination happens at the load balancer and data is passed along to the endpoint. 
 But SSL passthrough keeps the data encrypted as it travels through the load balancer - and this is what Kafka expects.
 
-#. Clone the Nginx Github repo:
+#. Add the Kubernetes NginX Helm repo and update the repo.
 
    ::
    
-     git clone https://github.com/helm/charts/tree/master/stable/nginx-ingress
+     helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+     helm repo update
 
 #. Install the Ngix controller:
 
    ::
    
-     helm upgrade --install nginx-operator stable/nginx-ingress \
-       --set controller.publishService.enabled=true \
+     helm upgrade  --install ingress-nginx ingress-nginx/ingress-nginx \
        --set controller.extraArgs.enable-ssl-passthrough="true"
        
 ================================

--- a/external-access-static-host-based/README.rst
+++ b/external-access-static-host-based/README.rst
@@ -202,7 +202,7 @@ Create an Ingress resource that includes a collection of rules that the Ingress
 control uses to route the inbound traffic to Kafka:
 
 #. In the resource file, ``ingress-service-hostbased.yaml``, replace ``$DOMAIN`` 
-   with the value of your ``$DOMAIN`` and uncomment the ``hosts:`` and ``host:`` settings.
+   with the value of your ``$DOMAIN``.
 
 #. Create the Ingress resource:
 

--- a/external-access-static-host-based/ingress-service-hostbased.yaml
+++ b/external-access-static-host-based/ingress-service-hostbased.yaml
@@ -1,42 +1,59 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-with-sni
   annotations:
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
-        - # b0.$DOMAIN 
-        - # b1.$DOMAIN
-        - # b2.$DOMAIN
-        - # kafka.$DOMAIN
+        - b0.$DOMAIN 
+        - b1.$DOMAIN
+        - b2.$DOMAIN
+        - kafka.$DOMAIN
   rules:
-    - host: # b0.$DOMAIN
+    - host: b0.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-0-internal
-              servicePort: 9092
-    - host: # b1.$DOMAIN
+          - path: /
+            pathType: Prefix
+            backend:
+              service: 
+                name: kafka-0-internal
+                port:
+                  number: 9092
+    - host: b1.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-1-internal
-              servicePort: 9092
-    - host: # b2.$DOMAIN
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-1-internal
+                port: 
+                  number: 9092
+    - host: b2.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-2-internal
-              servicePort: 9092
-    - host: # kafka.$DOMAIN
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-2-internal
+                port: 
+                  number: 9092
+    - host: kafka.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-bootstrap
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-bootstrap
+                port: 
+                  number: 9092

--- a/external-access-static-host-based/ingress-service-hostbased.yaml
+++ b/external-access-static-host-based/ingress-service-hostbased.yaml
@@ -1,59 +1,42 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ingress-with-sni
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ingress.kubernetes.io/ssl-passthrough: "true"
-    ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
 spec:
-  ingressClassName: nginx
   tls:
     - hosts:
-        - b0.$DOMAIN 
+        - kafka.$DOMAIN
+        - b0.$DOMAIN
         - b1.$DOMAIN
         - b2.$DOMAIN
-        - kafka.$DOMAIN
   rules:
     - host: b0.$DOMAIN
       http:
         paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service: 
-                name: kafka-0-internal
-                port:
-                  number: 9092
+          - backend:
+              serviceName: kafka-0-internal
+              servicePort: 9092
     - host: b1.$DOMAIN
       http:
         paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kafka-1-internal
-                port: 
-                  number: 9092
+          - backend:
+              serviceName: kafka-1-internal
+              servicePort: 9092
     - host: b2.$DOMAIN
       http:
         paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kafka-2-internal
-                port: 
-                  number: 9092
+          - backend:
+              serviceName: kafka-2-internal
+              servicePort: 9092
     - host: kafka.$DOMAIN
       http:
         paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kafka-bootstrap
-                port: 
-                  number: 9092
+          - backend:
+              serviceName: kafka-bootstrap
+              servicePort: 9092


### PR DESCRIPTION
The lab as written does not work because the git clone command is invalid. It's easier to use `helm repo add` instead. 

Also, the ingress yaml file is updated to use the `networking.k8s.io/v1` API.

This PR closes https://github.com/confluentinc/operator-earlyaccess/issues/47